### PR TITLE
add MIT license - allow other people in open source community to reuse

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2021 Github user: chenshuai2144 (https://github.com/chenshuai2144)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Hi @chenshuai2144 

### What is the Change?
I have added an MIT license to your repository so other people in the open source community can use your package.
Ant Design and many other Ant libraries use MIT license, this is why I chose it
- https://github.com/ant-design/ant-design/blob/master/LICENSE


### Motivation For Change
Many large company's have systems that look for a `license` or `LICENSE` file in a repository so they can determine if the software is safe to use. 

For example here is a warning I received after upgrading my `@ant-design/pro-table` version at my workplace. I didn't receive this warning in prior version's because it seems like this was added recently

![CleanShot 2022-03-18 at 08 39 50](https://user-images.githubusercontent.com/6743796/159034664-ff7d4e63-eb9b-4f8f-81e9-25bea2c782c2.png)


This is a summary of the MIT license
![CleanShot 2022-03-18 at 08 42 45](https://user-images.githubusercontent.com/6743796/159035259-72f1100c-6537-4661-bc73-83d7f77f00d2.png)



