### PR TITLE
add MIT license in package.json field

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2021 Github user: chenshuai2144 (https://github.com/chenshuai2144)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@chenshuai2144/sketch-color",
   "version": "1.0.7",
+  "license": "MIT",
   "scripts": {
     "start": "cross-env NODE_OPTIONS=--openssl-legacy-provider dumi dev",
     "docs:build": "dumi build",


### PR DESCRIPTION
Add `"license:"  "MIT"` in package.json file so npmjs.com and other tools that check this field can resolve correctly

![CleanShot 2022-03-26 at 07 29 19](https://user-images.githubusercontent.com/6743796/160244019-3acf8cf0-87d0-4ca0-8d18-f0e857d9c1b0.png)

@chenshuai2144 - not sure how the npm publishing process works, but once this change is commited we may need to publish a minor release so that NPM can pick up this new change

## References
- related to: https://github.com/chenshuai2144/sketch-color/pull/1
